### PR TITLE
Fix implementation of `chain::Confirm` for `ChannelManager`

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6196,7 +6196,7 @@ where
 		let channel_state = self.channel_state.lock().unwrap();
 		let mut res = Vec::with_capacity(channel_state.by_id.len());
 		for chan in channel_state.by_id.values() {
-			if let (Some(funding_txo), block_hash) = (chan.get_funding_txo(), chan.get_funding_tx_confirmed_in()) {
+			if let (Some(funding_txo), block_hash) = (chan.get_original_funding_txo(), chan.get_funding_tx_confirmed_in()) {
 				res.push((funding_txo.txid, block_hash));
 			}
 		}
@@ -6206,7 +6206,7 @@ where
 	fn transaction_unconfirmed(&self, txid: &Txid) {
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(&self.total_consistency_lock, &self.persistence_notifier);
 		self.do_chain_event(None, |channel| {
-			if let Some(funding_txo) = channel.get_funding_txo() {
+			if let Some(funding_txo) = channel.get_original_funding_txo() {
 				if funding_txo.txid == *txid {
 					channel.funding_transaction_unconfirmed(&self.logger).map(|()| (None, Vec::new(), None))
 				} else { Ok((None, Vec::new(), None)) }


### PR DESCRIPTION
Before this change, we could run into a situation where:

- LN channel was open and the funding transaction was confirmed.

- DLC channel was added, changing the LN channel's funding TXO to the one from the glue transaction.

- The next sync with the blockchain would have us looking for the glue transaction on-chain and expecting at least 1 confirmation. Not being able to find it, we would then report back to the `ChannelManager` via the `chain::Confirm::transaction_unconfirmed` API and let it know that the _funding_ transaction was unconfirmed, which is incorrect.

- This would lead to an unnecessary closure of the LN channel.