### PR TITLE
Do not panic if commitment update is missing

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1928,8 +1928,9 @@ where
 
 		let res = chan.monitor_updating_restored(&self.logger, &self.node_signer, self.genesis_hash, &self.default_configuration, self.best_block.read().unwrap().height());
 
+		let commitment_update = res.commitment_update.ok_or_else(|| APIError::ChannelUnavailable { err: "Could not find commitment update".to_string() })?;
 
-		return Ok(res.commitment_update.unwrap().commitment_signed)
+		Ok(commitment_update.commitment_signed)
 	}
 
 	fn on_commitment_signed_get_raa_internal(&self, channel_lock: &mut ChannelLock<<SP::Target as SignerProvider>::Signer>, commitment_signature: &secp256k1::ecdsa::Signature, htlc_signatures: &[secp256k1::ecdsa::Signature]) -> Result<msgs::RevokeAndACK, APIError> {


### PR DESCRIPTION
In the context of the LN-DLC protocol, if the peer has already _received_ the accept message and loses the connection to the counterparty while _processing_ the accept message the `commitment_update` will not be set.

Therefore, the `Option` needs to be properly handled and an error returned if no `commitment_update` is available.

The accept message will be reprocessed upon reconnection to the counterparty.